### PR TITLE
returnPPMplots not working (on windows); suggest Update checkEICFunctions.R

### DIFF
--- a/R/checkEICFunctions.R
+++ b/R/checkEICFunctions.R
@@ -444,6 +444,7 @@ filterPpmError <- function(approvedPeaks, useGap, varExpThresh,
 
         output <- file.path(plotDir,paste0(gsub(" ", "_", title), ".pdf"))
         output <- sub(":", "", output)
+        output <- sub("\n", "", output)
 
         ## error here...
         par(mar=c(1,1,1,1))


### PR DESCRIPTION
Nice algorithm!

On Windows R 4.0.3, setting returnPPMplots = TRUE results in an error due to file creation issues. Specifically, the \n needs to be stripped out of the file name string before passing it to grDevices. 